### PR TITLE
fix: use `geoms` attribute for shapely 2.0 compliance

### DIFF
--- a/DEM/MPI_interpolate_DEM.py
+++ b/DEM/MPI_interpolate_DEM.py
@@ -86,6 +86,7 @@ REFERENCES:
 
 UPDATE HISTORY:
     Updated 07/2023: using pathlib to define and operate on paths
+        use geoms attribute for shapely 2.0 compliance
     Updated 12/2022: single implicit import of grounding zone tools
     Updated 11/2022: new ArcticDEM and REMA mosaic index shapefiles
     Updated 09/2022: use tar virtual file system to extract images
@@ -543,7 +544,7 @@ def main():
         int_test = poly_obj.intersects(xy_point)
         if int_test:
             # extract intersected points
-            int_map = list(map(poly_obj.intersects,xy_point))
+            int_map = list(map(poly_obj.intersects, xy_point.geoms))
             int_indices, = np.nonzero(int_map)
             # set distributed_map indices to True for intersected points
             distributed_map[ind[int_indices]] = True

--- a/DEM/check_DEM_ICESat2_ATL06.py
+++ b/DEM/check_DEM_ICESat2_ATL06.py
@@ -44,6 +44,7 @@ REFERENCES:
 
 UPDATE HISTORY:
     Updated 07/2023: using pathlib to define and operate on paths
+        use geoms attribute for shapely 2.0 compliance
     Updated 12/2022: single implicit import of grounding zone tools
         refactored ICESat-2 data product read programs under io
     Updated 11/2022: new ArcticDEM and REMA mosaic index shapefiles
@@ -264,7 +265,7 @@ def check_DEM_ICESat2_ATL06(FILE, DIRECTORY=None, DEM_MODEL=None):
             int_test = poly_obj.intersects(xy_point)
             if int_test:
                 # extract intersected points
-                int_map = list(map(poly_obj.intersects,xy_point))
+                int_map = list(map(poly_obj.intersects, xy_point.geoms))
                 int_indices, = np.nonzero(int_map)
                 # set distributed_map indices to True for intersected points
                 intersection_map[key][int_indices] = True

--- a/GZ/MPI_reduce_ICESat2_ATL03_grounding_zone.py
+++ b/GZ/MPI_reduce_ICESat2_ATL03_grounding_zone.py
@@ -42,6 +42,7 @@ PROGRAM DEPENDENCIES:
 
 UPDATE HISTORY:
     Updated 07/2023: using pathlib to define and operate on paths
+        use geoms attribute for shapely 2.0 compliance
     Updated 12/2022: single implicit import of grounding zone tools
     Updated 11/2022: verify coordinate reference system of shapefile
     Updated 10/2022: simplied HDF5 file output to match other reduction programs
@@ -311,12 +312,12 @@ def main():
         # create empty intersection map array for receiving
         associated_map = np.zeros((n_pe),dtype=bool)
         # for each polygon
-        for poly_obj in mpoly_obj:
+        for poly_obj in mpoly_obj.geoms:
             # finds if points are encapsulated (in grounding zone)
             int_test = poly_obj.intersects(xy_point)
             if int_test:
                 # extract intersected points
-                int_map = list(map(poly_obj.intersects,xy_point))
+                int_map = list(map(poly_obj.intersects, xy_point.geoms))
                 int_indices, = np.nonzero(int_map)
                 # set distributed_map indices to True for intersected points
                 distributed_map[ind[int_indices]] = True

--- a/GZ/MPI_reduce_ICESat2_ATL06_grounding_zone.py
+++ b/GZ/MPI_reduce_ICESat2_ATL06_grounding_zone.py
@@ -42,6 +42,7 @@ PROGRAM DEPENDENCIES:
 
 UPDATE HISTORY:
     Updated 07/2023: using pathlib to define and operate on paths
+        use geoms attribute for shapely 2.0 compliance
     Updated 12/2022: single implicit import of grounding zone tools
     Updated 11/2022: verify coordinate reference system of shapefile
     Updated 10/2022: simplied HDF5 file output to match other reduction programs
@@ -309,12 +310,12 @@ def main():
         # create empty intersection map array for receiving
         associated_map = np.zeros((n_seg),dtype=bool)
         # for each polygon
-        for poly_obj in mpoly_obj:
+        for poly_obj in mpoly_obj.geoms:
             # finds if points are encapsulated (in grounding zone)
             int_test = poly_obj.intersects(xy_point)
             if int_test:
                 # extract intersected points
-                int_map = list(map(poly_obj.intersects,xy_point))
+                int_map = list(map(poly_obj.intersects, xy_point.geoms))
                 int_indices, = np.nonzero(int_map)
                 # set distributed_map indices to True for intersected points
                 distributed_map[ind[int_indices]] = True

--- a/GZ/MPI_reduce_ICESat2_ATL11_grounding_zone.py
+++ b/GZ/MPI_reduce_ICESat2_ATL11_grounding_zone.py
@@ -42,6 +42,7 @@ PROGRAM DEPENDENCIES:
 
 UPDATE HISTORY:
     Updated 07/2023: using pathlib to define and operate on paths
+        use geoms attribute for shapely 2.0 compliance
     Updated 12/2022: single implicit import of grounding zone tools
     Updated 11/2022: verify coordinate reference system of shapefile
     Updated 10/2022: simplied HDF5 file output to match other reduction programs
@@ -298,12 +299,12 @@ def main():
         # create empty intersection map array for receiving
         associated_map = np.zeros((n_points),dtype=bool)
         # for each polygon
-        for poly_obj in mpoly_obj:
+        for poly_obj in mpoly_obj.geoms:
             # finds if points are encapsulated (in grounding zone)
             int_test = poly_obj.intersects(xy_point)
             if int_test:
                 # extract intersected points
-                int_map = list(map(poly_obj.intersects,xy_point))
+                int_map = list(map(poly_obj.intersects, xy_point.geoms))
                 int_indices, = np.nonzero(int_map)
                 # set distributed_map indices to True for intersected points
                 distributed_map[ind[int_indices]] = True

--- a/tides/fit_tides_ICESat2_ATL11.py
+++ b/tides/fit_tides_ICESat2_ATL11.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 u"""
 fit_tides_ICESat2_ATL11.py
-Written by Tyler Sutterley (05/2023)
+Written by Tyler Sutterley (07/2023)
 Fits tidal amplitudes to ICESat-2 data in ice sheet grounding zones
 
 COMMAND LINE OPTIONS:
@@ -50,6 +50,7 @@ PROGRAM DEPENDENCIES:
     time.py: utilities for calculating time operations
 
 UPDATE HISTORY:
+    Updated 07/2023: verify crossover timescales are at least 1d
     Updated 05/2023: use timescale class for time conversion operations
         using pathlib to define and operate on paths
     Updated 12/2022: single implicit import of grounding zone tools
@@ -371,7 +372,7 @@ def fit_tides_ICESat2(tide_dir, INPUT_FILE,
             h2 = np.atleast_1d(h_corr['XT'].data[i2]) - geoid_h[s]
             # tide times
             t1 = timescale['AT'].tide[s,i1]
-            t2 = timescale['XT'].tide[i2]
+            t2 = np.atleast_1d(timescale['XT'].tide[i2])
             # combined tide and dac height
             ot1 = tide_ocean['AT'].data[s,i1] + IB['AT'].data[s,i1]
             ot2 = np.atleast_1d(tide_ocean['XT'].data[i2] + IB['XT'].data[i2])


### PR DESCRIPTION
fix: verify crossover timescales are at least 1d in fit