### PR TITLE
fix: use `clongdouble` instead of `longcomplex` for numpy 2.0

### DIFF
--- a/DEM/MPI_DEM_ICESat2_ATL03.py
+++ b/DEM/MPI_DEM_ICESat2_ATL03.py
@@ -119,7 +119,8 @@ gdal = gz.utilities.import_dependency('osgeo.gdal')
 h5py = gz.utilities.import_dependency('h5py')
 MPI = gz.utilities.import_dependency('mpi4py.MPI')
 pyproj = gz.utilities.import_dependency('pyproj')
-geometry = gz.utilities.import_dependency('shapely.geometry')
+shapely = gz.utilities.import_dependency('shapely')
+shapely.geometry = gz.utilities.import_dependency('shapely.geometry')
 timescale = gz.utilities.import_dependency('timescale')
 
 # digital elevation models
@@ -277,7 +278,7 @@ def read_DEM_index(index_file, DEM_MODEL):
         # extract Polar Stereographic coordinates for entity
         x = [ul[0],ur[0],lr[0],ll[0],ul2[0]]
         y = [ul[1],ur[1],lr[1],ll[1],ul2[1]]
-        poly_obj = geometry.Polygon(np.c_[x, y])
+        poly_obj = shapely.geometry.Polygon(np.c_[x, y])
         # Valid Polygon may not possess overlapping exterior or interior rings
         if (not poly_obj.is_valid):
             poly_obj = poly_obj.buffer(0)
@@ -493,7 +494,7 @@ def main():
         X,Y = transformer.transform(longitude, latitude)
 
         # convert reduced x and y to shapely multipoint object
-        xy_point = geometry.MultiPoint(list(zip(X[ind], Y[ind])))
+        xy_point = shapely.geometry.MultiPoint(list(zip(X[ind], Y[ind])))
 
         # create complete masks for each DEM tile
         associated_map = {}

--- a/DEM/MPI_DEM_ICESat2_ATL06.py
+++ b/DEM/MPI_DEM_ICESat2_ATL06.py
@@ -119,7 +119,8 @@ gdal = gz.utilities.import_dependency('osgeo.gdal')
 h5py = gz.utilities.import_dependency('h5py')
 MPI = gz.utilities.import_dependency('mpi4py.MPI')
 pyproj = gz.utilities.import_dependency('pyproj')
-geometry = gz.utilities.import_dependency('shapely.geometry')
+shapely = gz.utilities.import_dependency('shapely')
+shapely.geometry = gz.utilities.import_dependency('shapely.geometry')
 timescale = gz.utilities.import_dependency('timescale')
 
 # digital elevation models
@@ -277,7 +278,7 @@ def read_DEM_index(index_file, DEM_MODEL):
         # extract Polar Stereographic coordinates for entity
         x = [ul[0],ur[0],lr[0],ll[0],ul2[0]]
         y = [ul[1],ur[1],lr[1],ll[1],ul2[1]]
-        poly_obj = geometry.Polygon(np.c_[x, y])
+        poly_obj = shapely.geometry.Polygon(np.c_[x, y])
         # Valid Polygon may not possess overlapping exterior or interior rings
         if (not poly_obj.is_valid):
             poly_obj = poly_obj.buffer(0)
@@ -493,7 +494,7 @@ def main():
         X,Y = transformer.transform(longitude, latitude)
 
         # convert reduced x and y to shapely multipoint object
-        xy_point = geometry.MultiPoint(np.c_[X[ind], Y[ind]])
+        xy_point = shapely.geometry.MultiPoint(np.c_[X[ind], Y[ind]])
 
         # create complete masks for each DEM tile
         associated_map = {}

--- a/DEM/MPI_DEM_ICESat2_ATL11.py
+++ b/DEM/MPI_DEM_ICESat2_ATL11.py
@@ -98,7 +98,8 @@ gdal = gz.utilities.import_dependency('osgeo.gdal')
 h5py = gz.utilities.import_dependency('h5py')
 MPI = gz.utilities.import_dependency('mpi4py.MPI')
 pyproj = gz.utilities.import_dependency('pyproj')
-geometry = gz.utilities.import_dependency('shapely.geometry')
+shapely = gz.utilities.import_dependency('shapely')
+shapely.geometry = gz.utilities.import_dependency('shapely.geometry')
 timescale = gz.utilities.import_dependency('timescale')
 
 # digital elevation models
@@ -257,7 +258,7 @@ def read_DEM_index(index_file, DEM_MODEL):
         # extract Polar Stereographic coordinates for entity
         x = [ul[0],ur[0],lr[0],ll[0],ul2[0]]
         y = [ul[1],ur[1],lr[1],ll[1],ul2[1]]
-        poly_obj = geometry.Polygon(np.c_[x, y])
+        poly_obj = shapely.geometry.Polygon(np.c_[x, y])
         # Valid Polygon may not possess overlapping exterior or interior rings
         if (not poly_obj.is_valid):
             poly_obj = poly_obj.buffer(0)
@@ -470,7 +471,7 @@ def main():
             fileID[ptx]['latitude'][:])
 
         # convert reduced x and y to shapely multipoint object
-        xy_point = geometry.MultiPoint(np.c_[X[ind], Y[ind]])
+        xy_point = shapely.geometry.MultiPoint(np.c_[X[ind], Y[ind]])
 
         # create complete masks for each DEM tile
         associated_map = {}

--- a/DEM/MPI_DEM_ICESat_GLA12.py
+++ b/DEM/MPI_DEM_ICESat_GLA12.py
@@ -84,7 +84,8 @@ h5py = gz.utilities.import_dependency('h5py')
 MPI = gz.utilities.import_dependency('mpi4py.MPI')
 pyproj = gz.utilities.import_dependency('pyproj')
 pyTMD = gz.utilities.import_dependency('pyTMD')
-geometry = gz.utilities.import_dependency('shapely.geometry')
+shapely = gz.utilities.import_dependency('shapely')
+shapely.geometry = gz.utilities.import_dependency('shapely.geometry')
 
 # digital elevation models
 elevation_dir = {}
@@ -238,7 +239,7 @@ def read_DEM_index(index_file, DEM_MODEL):
         # extract Polar Stereographic coordinates for entity
         x = [ul[0],ur[0],lr[0],ll[0],ul2[0]]
         y = [ul[1],ur[1],lr[1],ll[1],ul2[1]]
-        poly_obj = geometry.Polygon(np.c_[x, y])
+        poly_obj = shapely.geometry.Polygon(np.c_[x, y])
         # Valid Polygon may not possess overlapping exterior or interior rings
         if (not poly_obj.is_valid):
             poly_obj = poly_obj.buffer(0)
@@ -463,7 +464,7 @@ def main():
     X,Y = transformer.transform(lon_40HZ, lat_40HZ)
 
     # convert reduced x and y to shapely multipoint object
-    xy_point = geometry.MultiPoint(np.c_[X[ind], Y[ind]])
+    xy_point = shapely.geometry.MultiPoint(np.c_[X[ind], Y[ind]])
 
     # create complete masks for each DEM tile
     associated_map = {}

--- a/DEM/MPI_interpolate_DEM.py
+++ b/DEM/MPI_interpolate_DEM.py
@@ -117,7 +117,8 @@ MPI = gz.utilities.import_dependency('mpi4py.MPI')
 gdal = gz.utilities.import_dependency('osgeo.gdal')
 pyproj = gz.utilities.import_dependency('pyproj')
 pyTMD = gz.utilities.import_dependency('pyTMD')
-geometry = gz.utilities.import_dependency('shapely.geometry')
+shapely = gz.utilities.import_dependency('shapely')
+shapely.geometry = gz.utilities.import_dependency('shapely.geometry')
 timescale = gz.utilities.import_dependency('timescale')
 
 # digital elevation models
@@ -292,7 +293,7 @@ def read_DEM_index(index_file, DEM_MODEL):
         # extract Polar Stereographic coordinates for entity
         x = [ul[0],ur[0],lr[0],ll[0],ul2[0]]
         y = [ul[1],ur[1],lr[1],ll[1],ul2[1]]
-        poly_obj = geometry.Polygon(np.c_[x, y])
+        poly_obj = shapely.geometry.Polygon(np.c_[x, y])
         # Valid Polygon may not possess overlapping exterior or interior rings
         if (not poly_obj.is_valid):
             poly_obj = poly_obj.buffer(0)
@@ -509,7 +510,7 @@ def main():
     dem_h.mask = np.ones((n_pts),dtype=bool)
 
     # convert reduced x and y to shapely multipoint object
-    xy_point = geometry.MultiPoint(np.c_[X[ind], Y[ind]])
+    xy_point = shapely.geometry.MultiPoint(np.c_[X[ind], Y[ind]])
 
     # create complete masks for each DEM tile
     associated_map = {}

--- a/DEM/check_DEM_ICESat2_ATL06.py
+++ b/DEM/check_DEM_ICESat2_ATL06.py
@@ -70,7 +70,8 @@ import grounding_zones as gz
 fiona = gz.utilities.import_dependency('fiona')
 is2tk = gz.utilities.import_dependency('icesat2_toolkit')
 pyproj = gz.utilities.import_dependency('pyproj')
-geometry = gz.utilities.import_dependency('shapely.geometry')
+shapely = gz.utilities.import_dependency('shapely')
+shapely.geometry = gz.utilities.import_dependency('shapely.geometry')
 
 # digital elevation models
 elevation_dir = {}
@@ -185,7 +186,7 @@ def read_DEM_index(index_file, DEM_MODEL):
         # extract Polar Stereographic coordinates for entity
         x = [ul[0],ur[0],lr[0],ll[0],ul2[0]]
         y = [ul[1],ur[1],lr[1],ll[1],ul2[1]]
-        poly_obj = geometry.Polygon(np.c_[x, y])
+        poly_obj = shapely.geometry.Polygon(np.c_[x, y])
         # Valid Polygon may not possess overlapping exterior or interior rings
         if (not poly_obj.is_valid):
             poly_obj = poly_obj.buffer(0)
@@ -258,7 +259,7 @@ def check_DEM_ICESat2_ATL06(INPUT_FILE,
         # convert projection from latitude/longitude to tile EPSG
         X,Y = transformer.transform(longitude, latitude)
         # convert reduced x and y to shapely multipoint object
-        xy_point = geometry.MultiPoint(np.c_[X, Y])
+        xy_point = shapely.geometry.MultiPoint(np.c_[X, Y])
 
         # create complete masks for each DEM tile
         intersection_map = {}

--- a/DEM/create_GIMP_tile_index.py
+++ b/DEM/create_GIMP_tile_index.py
@@ -71,9 +71,10 @@ import lxml.etree
 import grounding_zones as gz
 
 # attempt imports
-gdal = gz.utilities.import_dependency('osgeo.gdal')
-osr = gz.utilities.import_dependency('osgeo.osr')
-ogr = gz.utilities.import_dependency('osgeo.ogr')
+osgeo = gz.utilities.import_dependency('osgeo')
+osgeo.gdal = gz.utilities.import_dependency('osgeo.gdal')
+osgeo.osr = gz.utilities.import_dependency('osgeo.osr')
+osgeo.ogr = gz.utilities.import_dependency('osgeo.ogr')
 
 # PURPOSE: read GIMP image mosaic and create tile shapefile
 def create_GIMP_tile_index(base_dir, VERSION, MODE=0o775):
@@ -94,30 +95,30 @@ def create_GIMP_tile_index(base_dir, VERSION, MODE=0o775):
     parser = lxml.etree.HTMLParser()
 
      # save DEM tile outlines to ESRI shapefile
-    driver = ogr.GetDriverByName('Esri Shapefile')
+    driver = osgeo.ogr.GetDriverByName('Esri Shapefile')
     output_shapefile = ddir.joinpath(ff.format(VERSION,'shp'))
     ds = driver.CreateDataSource(str(output_shapefile))
     # set the spatial reference info
     # EPSG: 3413 (NSIDC Sea Ice Polar Stereographic North, WGS84)
-    SpatialReference = osr.SpatialReference()
+    SpatialReference = osgeo.osr.SpatialReference()
     SpatialReference.ImportFromEPSG(3413)
-    layer = ds.CreateLayer('', SpatialReference, ogr.wkbPolygon)
+    layer = ds.CreateLayer('', SpatialReference, osgeo.ogr.wkbPolygon)
     # Add shapefile attributes (following attributes from ArcticDEM and REMA)
-    layer.CreateField(ogr.FieldDefn('id', ogr.OFTInteger))
-    layer.CreateField(ogr.FieldDefn('name', ogr.OFTString))
-    layer.CreateField(ogr.FieldDefn('tile', ogr.OFTString))
-    layer.CreateField(ogr.FieldDefn('nd_value', ogr.OFTReal))
-    layer.CreateField(ogr.FieldDefn('resolution', ogr.OFTInteger))
-    layer.CreateField(ogr.FieldDefn('lastmodtm', ogr.OFTString))
-    layer.CreateField(ogr.FieldDefn('fileurl', ogr.OFTString))
-    layer.CreateField(ogr.FieldDefn('rel_ver', ogr.OFTReal))
-    layer.CreateField(ogr.FieldDefn('spec_type', ogr.OFTString))
-    layer.CreateField(ogr.FieldDefn('reg_src', ogr.OFTString))
-    field_area = ogr.FieldDefn('st_area_sh', ogr.OFTReal)
+    layer.CreateField(osgeo.ogr.FieldDefn('id', osgeo.ogr.OFTInteger))
+    layer.CreateField(osgeo.ogr.FieldDefn('name', osgeo.ogr.OFTString))
+    layer.CreateField(osgeo.ogr.FieldDefn('tile', osgeo.ogr.OFTString))
+    layer.CreateField(osgeo.ogr.FieldDefn('nd_value', osgeo.ogr.OFTReal))
+    layer.CreateField(osgeo.ogr.FieldDefn('resolution', osgeo.ogr.OFTInteger))
+    layer.CreateField(osgeo.ogr.FieldDefn('lastmodtm', osgeo.ogr.OFTString))
+    layer.CreateField(osgeo.ogr.FieldDefn('fileurl', osgeo.ogr.OFTString))
+    layer.CreateField(osgeo.ogr.FieldDefn('rel_ver', osgeo.ogr.OFTReal))
+    layer.CreateField(osgeo.ogr.FieldDefn('spec_type', osgeo.ogr.OFTString))
+    layer.CreateField(osgeo.ogr.FieldDefn('reg_src', osgeo.ogr.OFTString))
+    field_area = osgeo.ogr.FieldDefn('st_area_sh', osgeo.ogr.OFTReal)
     field_area.SetWidth(24)
     field_area.SetPrecision(10)
     layer.CreateField(field_area)
-    layer.CreateField(ogr.FieldDefn('st_length_', ogr.OFTInteger))
+    layer.CreateField(osgeo.ogr.FieldDefn('st_length_', osgeo.ogr.OFTInteger))
     defn = layer.GetLayerDefn()
 
     # create a counter for shapefile id
@@ -147,8 +148,8 @@ def create_GIMP_tile_index(base_dir, VERSION, MODE=0o775):
 
         # use GDAL memory-mapped file to read dem
         mmap_name = f'/vsimem/{uuid.uuid4().hex}'
-        gdal.FileFromMemBuffer(mmap_name, fileID.read())
-        dataset = gdal.Open(mmap_name)
+        osgeo.gdal.FileFromMemBuffer(mmap_name, fileID.read())
+        dataset = osgeo.gdal.Open(mmap_name)
 
         # get dimensions of tile
         xsize = dataset.RasterXSize
@@ -172,10 +173,10 @@ def create_GIMP_tile_index(base_dir, VERSION, MODE=0o775):
         st_length_ = int(2*(xmax-xmin) + 2*(ymax-ymin))
         # close the dataset
         dataset = None
-        gdal.Unlink(mmap_name)
+        osgeo.gdal.Unlink(mmap_name)
 
         # Create a new feature (attribute and geometry)
-        feature = ogr.Feature(defn)
+        feature = osgeo.ogr.Feature(defn)
         # Add shapefile attributes
         feature.SetField('id', id)
         feature.SetField('name', colname.replace('.tif',''))
@@ -192,11 +193,11 @@ def create_GIMP_tile_index(base_dir, VERSION, MODE=0o775):
         feature.SetField('st_length_', st_length_)
 
         # create LineString object and add x/y points
-        ring_obj = ogr.Geometry(ogr.wkbLinearRing)
+        ring_obj = osgeo.ogr.Geometry(osgeo.ogr.wkbLinearRing)
         for x, y in zip(xbox, ybox):
             ring_obj.AddPoint(x, y)
         # create Polygon object for LineString of tile
-        poly_obj = ogr.Geometry(ogr.wkbPolygon)
+        poly_obj = osgeo.ogr.Geometry(osgeo.ogr.wkbPolygon)
         poly_obj.AddGeometry(ring_obj)
         feature.SetGeometry(poly_obj)
         layer.CreateFeature(feature)

--- a/GZ/calculate_GZ_ICESat2_ATL03.py
+++ b/GZ/calculate_GZ_ICESat2_ATL03.py
@@ -75,7 +75,8 @@ fiona = gz.utilities.import_dependency('fiona')
 h5py = gz.utilities.import_dependency('h5py')
 is2tk = gz.utilities.import_dependency('icesat2_toolkit')
 pyproj = gz.utilities.import_dependency('pyproj')
-geometry = gz.utilities.import_dependency('shapely.geometry')
+shapely = gz.utilities.import_dependency('shapely')
+shapely.geometry = gz.utilities.import_dependency('shapely.geometry')
 timescale = gz.utilities.import_dependency('timescale')
 
 # grounded ice shapefiles
@@ -116,10 +117,10 @@ def read_grounded_ice(base_dir, HEM, VARIABLES=[0]):
     # extract the entities and assign by tile name
     for i,ent in enumerate(shape_entities):
         # extract coordinates for entity
-        line_obj = geometry.LineString(ent['geometry']['coordinates'])
+        line_obj = shapely.geometry.LineString(ent['geometry']['coordinates'])
         lines.append(line_obj)
     # create shapely multilinestring object
-    mline_obj = geometry.MultiLineString(lines)
+    mline_obj = shapely.geometry.MultiLineString(lines)
     # close the shapefile
     shape.close()
     # return the line string object for the ice sheet
@@ -292,7 +293,7 @@ def calculate_GZ_ICESat2(base_dir, INPUT_FILE,
             X,Y = transformer.transform(val['lon_ph'][i],val['lat_ph'][i])
             # shapely LineString object for altimetry segment
             try:
-                segment_line = geometry.LineString(np.c_[X, Y])
+                segment_line = shapely.geometry.LineString(np.c_[X, Y])
             except:
                 continue
             # determine if line segment intersects previously known GZ

--- a/GZ/calculate_GZ_ICESat2_ATL06.py
+++ b/GZ/calculate_GZ_ICESat2_ATL06.py
@@ -111,7 +111,8 @@ h5py = gz.utilities.import_dependency('h5py')
 is2tk = gz.utilities.import_dependency('icesat2_toolkit')
 plt = gz.utilities.import_dependency('matplotlib.pyplot')
 pyproj = gz.utilities.import_dependency('pyproj')
-geometry = gz.utilities.import_dependency('shapely.geometry')
+shapely = gz.utilities.import_dependency('shapely')
+shapely.geometry = gz.utilities.import_dependency('shapely.geometry')
 timescale = gz.utilities.import_dependency('timescale')
 
 # grounded ice shapefiles
@@ -152,10 +153,10 @@ def read_grounded_ice(base_dir, HEM, VARIABLES=[0]):
     # extract the entities and assign by tile name
     for i,ent in enumerate(shape_entities):
         # extract coordinates for entity
-        line_obj = geometry.LineString(ent['geometry']['coordinates'])
+        line_obj = shapely.geometry.LineString(ent['geometry']['coordinates'])
         lines.append(line_obj)
     # create shapely multilinestring object
-    mline_obj = geometry.MultiLineString(lines)
+    mline_obj = shapely.geometry.MultiLineString(lines)
     # close the shapefile
     shape.close()
     # return the line string object for the ice sheet
@@ -416,7 +417,7 @@ def calculate_GZ_ICESat2(base_dir, INPUT_FILE,
             X,Y = transformer.transform(v['longitude'][i],v['latitude'][i])
             # shapely LineString object for altimetry segment
             try:
-                segment_line = geometry.LineString(np.c_[X, Y])
+                segment_line = shapely.geometry.LineString(np.c_[X, Y])
             except:
                 continue
             # determine if line segment intersects previously known GZ

--- a/GZ/calculate_GZ_ICESat2_ATL11.py
+++ b/GZ/calculate_GZ_ICESat2_ATL11.py
@@ -115,7 +115,8 @@ h5py = gz.utilities.import_dependency('h5py')
 is2tk = gz.utilities.import_dependency('icesat2_toolkit')
 plt = gz.utilities.import_dependency('matplotlib.pyplot')
 pyproj = gz.utilities.import_dependency('pyproj')
-geometry = gz.utilities.import_dependency('shapely.geometry')
+shapely = gz.utilities.import_dependency('shapely')
+shapely.geometry = gz.utilities.import_dependency('shapely.geometry')
 timescale = gz.utilities.import_dependency('timescale')
 
 # grounded ice shapefiles
@@ -156,10 +157,10 @@ def read_grounded_ice(base_dir, HEM, VARIABLES=[0]):
     # extract the entities and assign by tile name
     for i,ent in enumerate(shape_entities):
         # extract coordinates for entity
-        line_obj = geometry.LineString(ent['geometry']['coordinates'])
+        line_obj = shapely.geometry.LineString(ent['geometry']['coordinates'])
         lines.append(line_obj)
     # create shapely multilinestring object
-    mline_obj = geometry.MultiLineString(lines)
+    mline_obj = shapely.geometry.MultiLineString(lines)
     # close the shapefile
     shape.close()
     # return the line string object for the ice sheet
@@ -506,7 +507,7 @@ def calculate_GZ_ICESat2(base_dir, INPUT_FILE,
                 coords = np.sqrt((X-X[i[0]])**2 + (Y-Y[i[0]])**2)
                 # shapely LineString object for altimetry segment
                 try:
-                    segment_line = geometry.LineString(np.c_[X[i], Y[i]])
+                    segment_line = shapely.geometry.LineString(np.c_[X[i], Y[i]])
                 except:
                     continue
                 # determine if line segment intersects previously known GZ

--- a/GZ/calculate_GZ_ICESat_GLA12.py
+++ b/GZ/calculate_GZ_ICESat_GLA12.py
@@ -89,7 +89,8 @@ fiona = gz.utilities.import_dependency('fiona')
 h5py = gz.utilities.import_dependency('h5py')
 plt = gz.utilities.import_dependency('matplotlib.pyplot')
 pyproj = gz.utilities.import_dependency('pyproj')
-geometry = gz.utilities.import_dependency('shapely.geometry')
+shapely = gz.utilities.import_dependency('shapely')
+shapely.geometry = gz.utilities.import_dependency('shapely.geometry')
 timescale = gz.utilities.import_dependency('timescale')
 
 # grounded ice shapefiles
@@ -122,10 +123,10 @@ def read_grounded_ice(base_dir, HEM, VARIABLES=[0]):
     # extract the entities and assign by tile name
     for i,ent in enumerate(shape_entities):
         # extract coordinates for entity
-        line_obj = geometry.LineString(ent['geometry']['coordinates'])
+        line_obj = shapely.geometry.LineString(ent['geometry']['coordinates'])
         lines.append(line_obj)
     # create shapely multilinestring object
-    mline_obj = geometry.MultiLineString(lines)
+    mline_obj = shapely.geometry.MultiLineString(lines)
     # close the shapefile
     shape.close()
     # return the line string object for the ice sheet
@@ -448,7 +449,7 @@ def calculate_GZ_ICESat(base_dir, INPUT_FILE,
             X,Y = transformer.transform(lon[i], lat[i])
             # shapely LineString object for altimetry segment
             try:
-                segment_line = geometry.LineString(np.c_[X, Y])
+                segment_line = shapely.geometry.LineString(np.c_[X, Y])
             except:
                 continue
             # determine if line segment intersects previously known GZ

--- a/GZ/calculate_grounding_zone.py
+++ b/GZ/calculate_grounding_zone.py
@@ -83,7 +83,8 @@ import grounding_zones as gz
 fiona = gz.utilities.import_dependency('fiona')
 pyTMD = gz.utilities.import_dependency('pyTMD')
 pyproj = gz.utilities.import_dependency('pyproj')
-geometry = gz.utilities.import_dependency('shapely.geometry')
+shapely = gz.utilities.import_dependency('shapely')
+shapely.geometry = gz.utilities.import_dependency('shapely.geometry')
 
 # grounded ice shapefiles
 grounded_shapefile = {}
@@ -123,10 +124,10 @@ def read_grounded_ice(base_dir, HEM, VARIABLES=[0]):
     # extract the entities and assign by tile name
     for i,ent in enumerate(shape_entities):
         # extract coordinates for entity
-        line_obj = geometry.LineString(ent['geometry']['coordinates'])
+        line_obj = shapely.geometry.LineString(ent['geometry']['coordinates'])
         lines.append(line_obj)
     # create shapely multilinestring object
-    mline_obj = geometry.MultiLineString(lines)
+    mline_obj = shapely.geometry.MultiLineString(lines)
     # close the shapefile
     shape.close()
     # return the line string object for the ice sheet
@@ -402,7 +403,7 @@ def calculate_grounding_zone(base_dir, input_file, output_file,
         # find valid indices within range
         i = sorted(set(np.arange(imin,imax+1)) & set(valid))
         # shapely LineString object for segment
-        segment_line = geometry.LineString(np.c_[X[i], Y[i]])
+        segment_line = shapely.geometry.LineString(np.c_[X[i], Y[i]])
         # determine if line segment intersects previously known GZ
         if segment_line.intersects(mline_obj):
             # horizontal eulerian distance from start of segment

--- a/SL/interp_sea_level_ICESat2_ATL06.py
+++ b/SL/interp_sea_level_ICESat2_ATL06.py
@@ -87,7 +87,8 @@ h5py = gz.utilities.import_dependency('h5py')
 is2tk = gz.utilities.import_dependency('icesat2_toolkit')
 netCDF4 = gz.utilities.import_dependency('netCDF4')
 pyproj = gz.utilities.import_dependency('pyproj')
-neighbors = gz.utilities.import_dependency('sklearn.neighbors')
+sklearn = gz.utilities.import_dependency('sklearn')
+sklearn.neighbors = gz.utilities.import_dependency('sklearn.neighbors')
 timescale = gz.utilities.import_dependency('timescale')
 
 # PURPOSE: set the hemisphere of interest based on the granule
@@ -104,9 +105,9 @@ def inverse_distance(x, y, z, xi, yi, SEARCH='BallTree', N=10, POWER=2.0):
     npts = len(xi)
     # create neighbors object for coordinates
     if (SEARCH == 'BallTree'):
-        tree = neighbors.BallTree(np.c_[x,y])
+        tree = sklearn.neighbors.BallTree(np.c_[x,y])
     elif (SEARCH == 'KDTree'):
-        tree = neighbors.KDTree(np.c_[x,y])
+        tree = sklearn.neighbors.KDTree(np.c_[x,y])
     # query the search tree to find the N closest points
     dist,indices = tree.query(np.c_[xi,yi], k=N, return_distance=True)
     # normalized weights if POWER > 0 (typically between 1 and 3)

--- a/SL/interp_sea_level_ICESat2_ATL07.py
+++ b/SL/interp_sea_level_ICESat2_ATL07.py
@@ -70,9 +70,9 @@ h5py = gz.utilities.import_dependency('h5py')
 is2tk = gz.utilities.import_dependency('icesat2_toolkit')
 netCDF4 = gz.utilities.import_dependency('netCDF4')
 pyproj = gz.utilities.import_dependency('pyproj')
-neighbors = gz.utilities.import_dependency('sklearn.neighbors')
+sklearn = gz.utilities.import_dependency('sklearn')
+sklearn.neighbors = gz.utilities.import_dependency('sklearn.neighbors')
 timescale = gz.utilities.import_dependency('timescale')
-
 
 # PURPOSE: set the hemisphere of interest based on ATL07 hemisphere code
 # HH Hemisphere code. Northern Hemisphere = 01, Southern Hemisphere = 02
@@ -89,9 +89,9 @@ def inverse_distance(x, y, z, xi, yi, SEARCH='BallTree', N=10, POWER=2.0):
     npts = len(xi)
     # create neighbors object for coordinates
     if (SEARCH == 'BallTree'):
-        tree = neighbors.BallTree(np.c_[x,y])
+        tree = sklearn.neighbors.BallTree(np.c_[x,y])
     elif (SEARCH == 'KDTree'):
-        tree = neighbors.KDTree(np.c_[x,y])
+        tree = sklearn.neighbors.KDTree(np.c_[x,y])
     # query the search tree to find the N closest points
     dist,indices = tree.query(np.c_[xi,yi], k=N, return_distance=True)
     # normalized weights if POWER > 0 (typically between 1 and 3)

--- a/SL/interp_sea_level_ICESat2_ATL11.py
+++ b/SL/interp_sea_level_ICESat2_ATL11.py
@@ -74,9 +74,9 @@ h5py = gz.utilities.import_dependency('h5py')
 is2tk = gz.utilities.import_dependency('icesat2_toolkit')
 netCDF4 = gz.utilities.import_dependency('netCDF4')
 pyproj = gz.utilities.import_dependency('pyproj')
-neighbors = gz.utilities.import_dependency('sklearn.neighbors')
+sklearn = gz.utilities.import_dependency('sklearn')
+sklearn.neighbors = gz.utilities.import_dependency('sklearn.neighbors')
 timescale = gz.utilities.import_dependency('timescale')
-
 
 # PURPOSE: set the hemisphere of interest based on the granule
 def set_hemisphere(GRANULE):
@@ -92,9 +92,9 @@ def inverse_distance(x, y, z, xi, yi, SEARCH='BallTree', N=10, POWER=2.0):
     npts = len(xi)
     # create neighbors object for coordinates
     if (SEARCH == 'BallTree'):
-        tree = neighbors.BallTree(np.c_[x,y])
+        tree = sklearn.neighbors.BallTree(np.c_[x,y])
     elif (SEARCH == 'KDTree'):
-        tree = neighbors.KDTree(np.c_[x,y])
+        tree = sklearn.neighbors.KDTree(np.c_[x,y])
     # query the search tree to find the N closest points
     dist,indices = tree.query(np.c_[xi,yi], k=N, return_distance=True)
     # normalized weights if POWER > 0 (typically between 1 and 3)

--- a/grounding_zones/fit.py
+++ b/grounding_zones/fit.py
@@ -1045,7 +1045,7 @@ def _polynomial(t_in, RELATIVE=Ellipsis, ORDER_TIME=3, **kwargs):
     # calculate epoch for calculating relative times
     if isinstance(RELATIVE, (list, np.ndarray)):
         t_rel = np.mean(RELATIVE)
-    elif isinstance(RELATIVE, (float, int, np.float_, np.int_)):
+    elif isinstance(RELATIVE, (float, int, np.float64, np.int_)):
         t_rel = np.copy(RELATIVE)
     elif RELATIVE in (Ellipsis, None):
         t_rel = t_in[RELATIVE].mean()

--- a/grounding_zones/utilities.py
+++ b/grounding_zones/utilities.py
@@ -95,9 +95,10 @@ def import_dependency(
     # check if the module name is a string
     msg = f"Invalid module name: '{name}'; must be a string"
     assert isinstance(name, str), msg
-    # try to import the module
+    # default error if module cannot be imported
     err = f"Missing optional dependency '{name}'. {extra}"
-    module = None
+    module = type('module', (), {})
+    # try to import the module
     try:
         module = importlib.import_module(name)
     except (ImportError, ModuleNotFoundError) as exc:

--- a/scripts/fit_surface_tiles.py
+++ b/scripts/fit_surface_tiles.py
@@ -465,8 +465,8 @@ def fit_surface_tiles(tile_files,
                         R2.findall(group).pop()
                     # quality summary HDF5 file for NSIDC granules
                     args = (PRD,RL,RGTP,ORB,INST,CYCL,TRK,SEG,GRAN,TYPE)
-                    glasmask = 'GLAH{0}_{1}_QA_{2}{3}{4}_{5}_{6}_{7}_{8}_{9}.h5'
-                    FILE3 = d1.joinpath(glasmask.format(*args))
+                    glas_qa = 'GLAH{0}_{1}_QA_{2}{3}{4}_{5}_{6}_{7}_{8}_{9}.h5'
+                    FILE3 = d1.joinpath(glas_qa.format(*args))
                     f3 = gz.io.multiprocess_h5py(FILE3, mode='r')
                     # extract number of points from group
                     indices = f1[group]['index'][:].copy()

--- a/subset/MPI_reduce_ICESat2_ATL03_RGI.py
+++ b/subset/MPI_reduce_ICESat2_ATL03_RGI.py
@@ -100,7 +100,8 @@ import grounding_zones as gz
 h5py = gz.utilities.import_dependency('h5py')
 MPI = gz.utilities.import_dependency('mpi4py.MPI')
 shapefile = gz.utilities.import_dependency('shapefile')
-geometry = gz.utilities.import_dependency('shapely.geometry')
+shapely = gz.utilities.import_dependency('shapely')
+shapely.geometry = gz.utilities.import_dependency('shapely.geometry')
 timescale = gz.utilities.import_dependency('timescale')
 
 # PURPOSE: keep track of MPI threads
@@ -193,7 +194,7 @@ def load_glacier_inventory(RGI_DIRECTORY,RGI_REGION):
         for p1,p2 in zip(parts[:-1], parts[1:]):
             poly_list.append(np.c_[points[p1:p2,0], points[p1:p2,1]])
         # convert poly_list into Polygon object with holes
-        poly_obj = geometry.Polygon(poly_list[0], poly_list[1:])
+        poly_obj = shapely.geometry.Polygon(poly_list[0], poly_list[1:])
         # Valid Polygon may not possess overlapping exterior or interior rings
         if (not poly_obj.is_valid):
             poly_obj = poly_obj.buffer(0)
@@ -303,7 +304,7 @@ def main():
         latitude = fileID[gtx]['heights']['lat_ph'][:]
 
         # convert reduced lat/lon to shapely multipoint object
-        xy_point = geometry.MultiPoint(np.c_[longitude[ind], latitude[ind]])
+        xy_point = shapely.geometry.MultiPoint(np.c_[longitude[ind], latitude[ind]])
 
         # create distributed intersection map for calculation
         distributed_map = np.zeros((n_pe),dtype=bool)

--- a/subset/MPI_reduce_ICESat2_ATL03_grounding_zone.py
+++ b/subset/MPI_reduce_ICESat2_ATL03_grounding_zone.py
@@ -85,7 +85,8 @@ fiona = gz.utilities.import_dependency('fiona')
 h5py = gz.utilities.import_dependency('h5py')
 MPI = gz.utilities.import_dependency('mpi4py.MPI')
 pyproj = gz.utilities.import_dependency('pyproj')
-geometry = gz.utilities.import_dependency('shapely.geometry')
+shapely = gz.utilities.import_dependency('shapely')
+shapely.geometry = gz.utilities.import_dependency('shapely.geometry')
 timescale = gz.utilities.import_dependency('timescale')
 
 # buffered shapefile
@@ -185,13 +186,13 @@ def load_grounding_zone(base_dir, HEM, BUFFER, shapefile=None):
             x,y = np.transpose(coords)
             poly_list.append(list(zip(x,y)))
         # convert poly_list into Polygon object with holes
-        poly_obj = geometry.Polygon(poly_list[0], holes=poly_list[1:])
+        poly_obj = shapely.geometry.Polygon(poly_list[0], holes=poly_list[1:])
         # Valid Polygon cannot have overlapping exterior or interior rings
         if (not poly_obj.is_valid):
             poly_obj = poly_obj.buffer(0)
         polygons.append(poly_obj)
     # create shapely multipolygon object
-    mpoly_obj = geometry.MultiPolygon(polygons)
+    mpoly_obj = shapely.geometry.MultiPolygon(polygons)
     # close the shapefile
     shape.close()
     # return the polygon object for the ice sheet
@@ -317,7 +318,7 @@ def main():
         # convert lat/lon to polar stereographic
         X,Y = transformer.transform(longitude[ind], latitude[ind])
         # convert reduced x and y to shapely multipoint object
-        xy_point = geometry.MultiPoint(np.c_[X, Y])
+        xy_point = shapely.geometry.MultiPoint(np.c_[X, Y])
 
         # create distributed intersection map for calculation
         distributed_map = np.zeros((n_pe),dtype=bool)

--- a/subset/MPI_reduce_ICESat2_ATL06_RGI.py
+++ b/subset/MPI_reduce_ICESat2_ATL06_RGI.py
@@ -99,7 +99,8 @@ import grounding_zones as gz
 h5py = gz.utilities.import_dependency('h5py')
 MPI = gz.utilities.import_dependency('mpi4py.MPI')
 shapefile = gz.utilities.import_dependency('shapefile')
-geometry = gz.utilities.import_dependency('shapely.geometry')
+shapely = gz.utilities.import_dependency('shapely')
+shapely.geometry = gz.utilities.import_dependency('shapely.geometry')
 timescale = gz.utilities.import_dependency('timescale')
 
 # PURPOSE: keep track of MPI threads
@@ -192,7 +193,7 @@ def load_glacier_inventory(RGI_DIRECTORY,RGI_REGION):
         for p1,p2 in zip(parts[:-1], parts[1:]):
             poly_list.append(np.c_[points[p1:p2,0], points[p1:p2,1]])
         # convert poly_list into Polygon object with holes
-        poly_obj = geometry.Polygon(poly_list[0], poly_list[1:])
+        poly_obj = shapely.geometry.Polygon(poly_list[0], poly_list[1:])
         # Valid Polygon may not possess overlapping exterior or interior rings
         if (not poly_obj.is_valid):
             poly_obj = poly_obj.buffer(0)
@@ -304,7 +305,7 @@ def main():
         latitude = fileID[gtx]['land_ice_segments']['latitude'][:].copy()
 
         # convert reduced lat/lon to shapely multipoint object
-        xy_point = geometry.MultiPoint(np.c_[longitude[ind], latitude[ind]])
+        xy_point = shapely.geometry.MultiPoint(np.c_[longitude[ind], latitude[ind]])
 
         # create distributed intersection map for calculation
         distributed_map = np.zeros((n_seg),dtype=bool)

--- a/subset/MPI_reduce_ICESat2_ATL06_drainages.py
+++ b/subset/MPI_reduce_ICESat2_ATL06_drainages.py
@@ -79,7 +79,8 @@ h5py = gz.utilities.import_dependency('h5py')
 MPI = gz.utilities.import_dependency('mpi4py.MPI')
 pyproj = gz.utilities.import_dependency('pyproj')
 shapefile = gz.utilities.import_dependency('shapefile')
-geometry = gz.utilities.import_dependency('shapely.geometry')
+shapely = gz.utilities.import_dependency('shapely')
+shapely.geometry = gz.utilities.import_dependency('shapely.geometry')
 timescale = gz.utilities.import_dependency('timescale')
 
 # IMBIE-2 Drainage basins
@@ -161,7 +162,7 @@ def load_IMBIE2_basins(basin_dir, HEM, EPSG):
             # extract Polar-Stereographic coordinates for record
             points = np.array(shape_entities[i].points)
             # shapely polygon object for region outline
-            poly_obj = geometry.Polygon(np.c_[points[:,0],points[:,1]])
+            poly_obj = shapely.geometry.Polygon(np.c_[points[:,0],points[:,1]])
         elif (HEM == 'N'):
             # no glaciers or ice caps
             i,=[i for i,a in enumerate(shape_attributes) if (a[0] == REGION)]
@@ -177,7 +178,7 @@ def load_IMBIE2_basins(basin_dir, HEM, EPSG):
                 X,Y = transformer.transform(points[p1:p2,0],points[p1:p2,1])
                 poly_list.append(np.c_[X,Y])
             # convert poly_list into Polygon object with holes
-            poly_obj = geometry.Polygon(poly_list[0], poly_list[1:])
+            poly_obj = shapely.geometry.Polygon(poly_list[0], poly_list[1:])
         # check if polygon object is valid
         if (not poly_obj.is_valid):
             poly_obj = poly_obj.buffer(0)
@@ -299,7 +300,7 @@ def main():
         # convert lat/lon to polar stereographic
         X,Y = transformer.transform(longitude[ind], latitude[ind])
         # convert reduced x and y to shapely multipoint object
-        xy_point = geometry.MultiPoint(np.c_[X, Y])
+        xy_point = shapely.geometry.MultiPoint(np.c_[X, Y])
 
         # calculate mask for each drainage basin in the dictionary
         associated_map = {}

--- a/subset/MPI_reduce_ICESat2_ATL06_grounded.py
+++ b/subset/MPI_reduce_ICESat2_ATL06_grounded.py
@@ -83,7 +83,8 @@ h5py = gz.utilities.import_dependency('h5py')
 MPI = gz.utilities.import_dependency('mpi4py.MPI')
 pyproj = gz.utilities.import_dependency('pyproj')
 shapefile = gz.utilities.import_dependency('shapefile')
-geometry = gz.utilities.import_dependency('shapely.geometry')
+shapely = gz.utilities.import_dependency('shapely')
+shapely.geometry = gz.utilities.import_dependency('shapely.geometry')
 timescale = gz.utilities.import_dependency('timescale')
 
 # regional grounded ice files
@@ -184,7 +185,7 @@ def load_grounded_ice(base_dir, BUFFER, HEM, AREA=0.0):
         for p1,p2 in zip(parts[:-1],parts[1:]):
             poly_list.append(list(zip(points[p1:p2,0],points[p1:p2,1])))
         # convert poly_list into Polygon object with holes
-        poly_obj = geometry.Polygon(poly_list[0],poly_list[1:])
+        poly_obj = shapely.geometry.Polygon(poly_list[0],poly_list[1:])
         if (poly_obj.area < (AREA*1e6)):
             continue
         # buffer polygon object and add to total polygon dictionary object
@@ -298,7 +299,7 @@ def main():
         # convert lat/lon to polar stereographic
         X,Y = transformer.transform(longitude[ind], latitude[ind])
         # convert reduced x and y to shapely multipoint object
-        xy_point = geometry.MultiPoint(np.c_[X, Y])
+        xy_point = shapely.geometry.MultiPoint(np.c_[X, Y])
 
         # calculate mask for each grounded region in the dictionary
         associated_map = {}

--- a/subset/MPI_reduce_ICESat2_ATL06_grounding_zone.py
+++ b/subset/MPI_reduce_ICESat2_ATL06_grounding_zone.py
@@ -86,7 +86,8 @@ fiona = gz.utilities.import_dependency('fiona')
 h5py = gz.utilities.import_dependency('h5py')
 MPI = gz.utilities.import_dependency('mpi4py.MPI')
 pyproj = gz.utilities.import_dependency('pyproj')
-geometry = gz.utilities.import_dependency('shapely.geometry')
+shapely = gz.utilities.import_dependency('shapely')
+shapely.geometry = gz.utilities.import_dependency('shapely.geometry')
 timescale = gz.utilities.import_dependency('timescale')
 
 # buffered shapefile
@@ -185,13 +186,13 @@ def load_grounding_zone(base_dir, HEM, BUFFER, shapefile=None):
             x,y = np.transpose(coords)
             poly_list.append(list(zip(x,y)))
         # convert poly_list into Polygon object with holes
-        poly_obj = geometry.Polygon(poly_list[0], holes=poly_list[1:])
+        poly_obj = shapely.geometry.Polygon(poly_list[0], holes=poly_list[1:])
         # Valid Polygon cannot have overlapping exterior or interior rings
         if (not poly_obj.is_valid):
             poly_obj = poly_obj.buffer(0)
         polygons.append(poly_obj)
     # create shapely multipolygon object
-    mpoly_obj = geometry.MultiPolygon(polygons)
+    mpoly_obj = shapely.geometry.MultiPolygon(polygons)
     # close the shapefile
     shape.close()
     # return the polygon object for the ice sheet
@@ -315,7 +316,7 @@ def main():
         # convert lat/lon to polar stereographic
         X,Y = transformer.transform(longitude[ind], latitude[ind])
         # convert reduced x and y to shapely multipoint object
-        xy_point = geometry.MultiPoint(np.c_[X, Y])
+        xy_point = shapely.geometry.MultiPoint(np.c_[X, Y])
 
         # create distributed intersection map for calculation
         distributed_map = np.zeros((n_seg),dtype=bool)

--- a/subset/MPI_reduce_ICESat2_ATL06_ice_shelves.py
+++ b/subset/MPI_reduce_ICESat2_ATL06_ice_shelves.py
@@ -81,7 +81,8 @@ h5py = gz.utilities.import_dependency('h5py')
 MPI = gz.utilities.import_dependency('mpi4py.MPI')
 pyproj = gz.utilities.import_dependency('pyproj')
 shapefile = gz.utilities.import_dependency('shapefile')
-geometry = gz.utilities.import_dependency('shapely.geometry')
+shapely = gz.utilities.import_dependency('shapely')
+shapely.geometry = gz.utilities.import_dependency('shapely.geometry')
 timescale = gz.utilities.import_dependency('timescale')
 
 # regional ice shelf files
@@ -176,7 +177,7 @@ def load_ice_shelves(base_dir, BUFFER, HEM):
         for p1,p2 in zip(parts[:-1],parts[1:]):
             poly_list.append(list(zip(points[p1:p2,0],points[p1:p2,1])))
         # convert poly_list into Polygon object with holes
-        poly_obj = geometry.Polygon(poly_list[0], poly_list[1:])
+        poly_obj = shapely.geometry.Polygon(poly_list[0], poly_list[1:])
         # buffer polygon object and add to total polygon dictionary object
         poly_dict[shape_attributes[i][0]] = poly_obj.buffer(BUFFER*1e3)
     # return the polygon object and the input file name
@@ -286,7 +287,7 @@ def main():
         # convert lat/lon to polar stereographic
         X,Y = transformer.transform(longitude[ind], latitude[ind])
         # convert reduced x and y to shapely multipoint object
-        xy_point = geometry.MultiPoint(np.c_[X, Y])
+        xy_point = shapely.geometry.MultiPoint(np.c_[X, Y])
 
         # calculate mask for each ice shelf in the dictionary
         associated_map = {}

--- a/subset/MPI_reduce_ICESat2_ATL11_RGI.py
+++ b/subset/MPI_reduce_ICESat2_ATL11_RGI.py
@@ -92,7 +92,8 @@ import grounding_zones as gz
 h5py = gz.utilities.import_dependency('h5py')
 MPI = gz.utilities.import_dependency('mpi4py.MPI')
 shapefile = gz.utilities.import_dependency('shapefile')
-geometry = gz.utilities.import_dependency('shapely.geometry')
+shapely = gz.utilities.import_dependency('shapely')
+shapely.geometry = gz.utilities.import_dependency('shapely.geometry')
 timescale = gz.utilities.import_dependency('timescale')
 
 # PURPOSE: keep track of MPI threads
@@ -185,7 +186,7 @@ def load_glacier_inventory(RGI_DIRECTORY,RGI_REGION):
         for p1,p2 in zip(parts[:-1], parts[1:]):
             poly_list.append(np.c_[points[p1:p2,0], points[p1:p2,1]])
         # convert poly_list into Polygon object with holes
-        poly_obj = geometry.Polygon(poly_list[0], poly_list[1:])
+        poly_obj = shapely.geometry.Polygon(poly_list[0], poly_list[1:])
         # Valid Polygon may not possess overlapping exterior or interior rings
         if (not poly_obj.is_valid):
             poly_obj = poly_obj.buffer(0)
@@ -289,7 +290,7 @@ def main():
         # convert reduced lat/lon to shapely multipoint object
         longitude = fileID[ptx]['longitude'][:].copy()
         latitude = fileID[ptx]['latitude'][:].copy()
-        xy_point = geometry.MultiPoint(np.c_[longitude[ind], latitude[ind]])
+        xy_point = shapely.geometry.MultiPoint(np.c_[longitude[ind], latitude[ind]])
 
         # create distributed intersection map for calculation
         distributed_map = np.zeros((n_points),dtype=bool)

--- a/subset/MPI_reduce_ICESat2_ATL11_drainages.py
+++ b/subset/MPI_reduce_ICESat2_ATL11_drainages.py
@@ -71,7 +71,8 @@ h5py = gz.utilities.import_dependency('h5py')
 MPI = gz.utilities.import_dependency('mpi4py.MPI')
 pyproj = gz.utilities.import_dependency('pyproj')
 shapefile = gz.utilities.import_dependency('shapefile')
-geometry = gz.utilities.import_dependency('shapely.geometry')
+shapely = gz.utilities.import_dependency('shapely')
+shapely.geometry = gz.utilities.import_dependency('shapely.geometry')
 timescale = gz.utilities.import_dependency('timescale')
 
 # IMBIE-2 Drainage basins
@@ -153,7 +154,7 @@ def load_IMBIE2_basins(basin_dir, HEM, EPSG):
             # extract Polar-Stereographic coordinates for record
             points = np.array(shape_entities[i].points)
             # shapely polygon object for region outline
-            poly_obj = geometry.Polygon(np.c_[points[:,0], points[:,1]])
+            poly_obj = shapely.geometry.Polygon(np.c_[points[:,0], points[:,1]])
         elif (HEM == 'N'):
             # no glaciers or ice caps
             i,=[i for i,a in enumerate(shape_attributes) if (a[0] == REGION)]
@@ -169,7 +170,7 @@ def load_IMBIE2_basins(basin_dir, HEM, EPSG):
                 X,Y = transformer.transform(points[p1:p2,0],points[p1:p2,1])
                 poly_list.append(np.c_[X,Y])
             # convert poly_list into Polygon object with holes
-            poly_obj = geometry.Polygon(poly_list[0],poly_list[1:])
+            poly_obj = shapely.geometry.Polygon(poly_list[0],poly_list[1:])
         # check if polygon object is valid
         if (not poly_obj.is_valid):
             poly_obj = poly_obj.buffer(0)
@@ -284,7 +285,7 @@ def main():
         X,Y = transformer.transform(fileID[ptx]['longitude'][:],
             fileID[ptx]['latitude'][:])
         # convert reduced x and y to shapely multipoint object
-        xy_point = geometry.MultiPoint(np.c_[X[ind], Y[ind]])
+        xy_point = shapely.geometry.MultiPoint(np.c_[X[ind], Y[ind]])
 
         # calculate mask for each drainage basin in the dictionary
         associated_map = {}

--- a/subset/MPI_reduce_ICESat2_ATL11_grounded.py
+++ b/subset/MPI_reduce_ICESat2_ATL11_grounded.py
@@ -75,7 +75,8 @@ h5py = gz.utilities.import_dependency('h5py')
 MPI = gz.utilities.import_dependency('mpi4py.MPI')
 pyproj = gz.utilities.import_dependency('pyproj')
 shapefile = gz.utilities.import_dependency('shapefile')
-geometry = gz.utilities.import_dependency('shapely.geometry')
+shapely = gz.utilities.import_dependency('shapely')
+shapely.geometry = gz.utilities.import_dependency('shapely.geometry')
 timescale = gz.utilities.import_dependency('timescale')
 
 # regional grounded ice files
@@ -176,7 +177,7 @@ def load_grounded_ice(base_dir, BUFFER, HEM, AREA=0.0):
         for p1,p2 in zip(parts[:-1],parts[1:]):
             poly_list.append(list(zip(points[p1:p2,0],points[p1:p2,1])))
         # convert poly_list into Polygon object with holes
-        poly_obj = geometry.Polygon(poly_list[0], poly_list[1:])
+        poly_obj = shapely.geometry.Polygon(poly_list[0], poly_list[1:])
         if (poly_obj.area < (AREA*1e6)):
             continue
         # buffer polygon object and add to total polygon dictionary object
@@ -283,7 +284,7 @@ def main():
         X,Y = transformer.transform(fileID[ptx]['longitude'][:],
             fileID[ptx]['latitude'][:])
         # convert reduced x and y to shapely multipoint object
-        xy_point = geometry.MultiPoint(np.c_[X[ind], Y[ind]])
+        xy_point = shapely.geometry.MultiPoint(np.c_[X[ind], Y[ind]])
 
         # calculate mask for each grounded ice region in the dictionary
         associated_map = {}

--- a/subset/MPI_reduce_ICESat2_ATL11_grounding_zone.py
+++ b/subset/MPI_reduce_ICESat2_ATL11_grounding_zone.py
@@ -77,7 +77,8 @@ fiona = gz.utilities.import_dependency('fiona')
 h5py = gz.utilities.import_dependency('h5py')
 MPI = gz.utilities.import_dependency('mpi4py.MPI')
 pyproj = gz.utilities.import_dependency('pyproj')
-geometry = gz.utilities.import_dependency('shapely.geometry')
+shapely = gz.utilities.import_dependency('shapely')
+shapely.geometry = gz.utilities.import_dependency('shapely.geometry')
 timescale = gz.utilities.import_dependency('timescale')
 
 # buffered shapefile
@@ -177,13 +178,13 @@ def load_grounding_zone(base_dir, HEM, BUFFER, shapefile=None):
             x,y = np.transpose(coords)
             poly_list.append(list(zip(x,y)))
         # convert poly_list into Polygon object with holes
-        poly_obj = geometry.Polygon(poly_list[0], holes=poly_list[1:])
+        poly_obj = shapely.geometry.Polygon(poly_list[0], holes=poly_list[1:])
         # Valid Polygon cannot have overlapping exterior or interior rings
         if (not poly_obj.is_valid):
             poly_obj = poly_obj.buffer(0)
         polygons.append(poly_obj)
     # create shapely multipolygon object
-    mpoly_obj = geometry.MultiPolygon(polygons)
+    mpoly_obj = shapely.geometry.MultiPolygon(polygons)
     # close the shapefile
     shape.close()
     # return the polygon object for the ice sheet
@@ -304,7 +305,7 @@ def main():
         X,Y = transformer.transform(fileID[ptx]['longitude'][:],
             fileID[ptx]['latitude'][:])
         # convert reduced x and y to shapely multipoint object
-        xy_point = geometry.MultiPoint(np.c_[X[ind], Y[ind]])
+        xy_point = shapely.geometry.MultiPoint(np.c_[X[ind], Y[ind]])
 
         # create distributed intersection map for calculation
         distributed_map = np.zeros((n_points),dtype=bool)

--- a/subset/MPI_reduce_ICESat2_ATL11_ice_shelves.py
+++ b/subset/MPI_reduce_ICESat2_ATL11_ice_shelves.py
@@ -73,7 +73,8 @@ h5py = gz.utilities.import_dependency('h5py')
 MPI = gz.utilities.import_dependency('mpi4py.MPI')
 pyproj = gz.utilities.import_dependency('pyproj')
 shapefile = gz.utilities.import_dependency('shapefile')
-geometry = gz.utilities.import_dependency('shapely.geometry')
+shapely = gz.utilities.import_dependency('shapely')
+shapely.geometry = gz.utilities.import_dependency('shapely.geometry')
 timescale = gz.utilities.import_dependency('timescale')
 
 # regional ice shelf files
@@ -178,7 +179,7 @@ def load_ice_shelves(base_dir, BUFFER, HEM):
         for p1,p2 in zip(parts[:-1],parts[1:]):
             poly_list.append(list(zip(points[p1:p2,0],points[p1:p2,1])))
         # convert poly_list into Polygon object with holes
-        poly_obj = geometry.Polygon(poly_list[0], poly_list[1:])
+        poly_obj = shapely.geometry.Polygon(poly_list[0], poly_list[1:])
         # buffer polygon object and add to total polygon dictionary object
         poly_dict[shape_attributes[i][0]] = poly_obj.buffer(BUFFER*1e3)
     # return the polygon object and the input file name
@@ -298,7 +299,7 @@ def main():
         X,Y = transformer.transform(fileID[ptx]['longitude'][:],
             fileID[ptx]['latitude'][:])
         # convert reduced x and y to shapely multipoint object
-        xy_point = geometry.MultiPoint(np.c_[X[ind], Y[ind]])
+        xy_point = shapely.geometry.MultiPoint(np.c_[X[ind], Y[ind]])
 
         # calculate mask for each ice shelf in the dictionary
         associated_map = {}

--- a/subset/MPI_reduce_ICESat_GLA12_grounding_zone.py
+++ b/subset/MPI_reduce_ICESat_GLA12_grounding_zone.py
@@ -64,7 +64,8 @@ h5py = gz.utilities.import_dependency('h5py')
 MPI = gz.utilities.import_dependency('mpi4py.MPI')
 pyproj = gz.utilities.import_dependency('pyproj')
 pyTMD = gz.utilities.import_dependency('pyTMD')
-geometry = gz.utilities.import_dependency('shapely.geometry')
+shapely = gz.utilities.import_dependency('shapely')
+shapely.geometry = gz.utilities.import_dependency('shapely.geometry')
 timescale = gz.utilities.import_dependency('timescale')
 
 # buffered shapefile
@@ -160,13 +161,13 @@ def load_grounding_zone(base_dir, HEM, BUFFER, shapefile=None):
             x,y = np.transpose(coords)
             poly_list.append(list(zip(x,y)))
         # convert poly_list into Polygon object with holes
-        poly_obj = geometry.Polygon(poly_list[0], holes=poly_list[1:])
+        poly_obj = shapely.geometry.Polygon(poly_list[0], holes=poly_list[1:])
         # Valid Polygon cannot have overlapping exterior or interior rings
         if (not poly_obj.is_valid):
             poly_obj = poly_obj.buffer(0)
         polygons.append(poly_obj)
     # create shapely multipolygon object
-    mpoly_obj = geometry.MultiPolygon(polygons)
+    mpoly_obj = shapely.geometry.MultiPolygon(polygons)
     # close the shapefile
     shape.close()
     # return the polygon object for the ice sheet
@@ -283,7 +284,7 @@ def main():
     # convert lat/lon to polar stereographic
     X,Y = transformer.transform(lon_40HZ[ind], lat_40HZ[ind])
     # convert reduced x and y to shapely multipoint object
-    xy_point = geometry.MultiPoint(np.c_[X, Y])
+    xy_point = shapely.geometry.MultiPoint(np.c_[X, Y])
 
     # create distributed intersection map for calculation
     distributed_map = np.zeros((n_40HZ), dtype=bool)

--- a/tides/compute_OPT_ICESat_GLA12.py
+++ b/tides/compute_OPT_ICESat_GLA12.py
@@ -61,7 +61,7 @@ UPDATE HISTORY:
         use constants class from pyTMD for ellipsoidal parameters
         refactored pyTMD tide model structure
     Updated 07/2022: place some imports within try/except statements
-    Updated 04/2022: use longcomplex data format to be windows compliant
+    Updated 04/2022: use clongdouble data format to be windows compliant
         use argparse descriptions within sphinx documentation
     Updated 02/2022: save ICESat campaign attribute to output file
     Updated 10/2021: using python logging for handling verbose output
@@ -225,7 +225,7 @@ def compute_OPT_ICESat(INPUT_FILE,
             iur[:,::-1].real, kx=1, ky=1)
         f2 = scipy.interpolate.RectBivariateSpline(ilon, ilat[::-1],
             iur[:,::-1].imag, kx=1, ky=1)
-        UR = np.zeros((n_40HZ),dtype=np.longcomplex)
+        UR = np.zeros((n_40HZ),dtype=np.clongdouble)
         UR.real = f1.ev(lon_40HZ,latitude_geocentric)
         UR.imag = f2.ev(lon_40HZ,latitude_geocentric)
     else:

--- a/tides/compute_OPT_icebridge_data.py
+++ b/tides/compute_OPT_icebridge_data.py
@@ -59,7 +59,7 @@ UPDATE HISTORY:
     Updated 07/2022: update imports of ATM1b QFIT functions to released version
         place some imports within try/except statements
     Updated 04/2022: include utf-8 encoding in reads to be windows compliant
-        use longcomplex data format to be windows compliant
+        use clongdouble data format to be windows compliant
         use argparse descriptions within sphinx documentation
     Updated 10/2021: using python logging for handling verbose output
         using collections to store attributes in order of creation
@@ -271,7 +271,7 @@ def compute_OPT_icebridge_data(arg,
             iur[:,::-1].real, kx=1, ky=1)
         f2 = scipy.interpolate.RectBivariateSpline(ilon, ilat[::-1],
             iur[:,::-1].imag, kx=1, ky=1)
-        UR = np.zeros((file_lines),dtype=np.longcomplex)
+        UR = np.zeros((file_lines),dtype=np.clongdouble)
         UR.real = f1.ev(lon,latitude_geocentric)
         UR.imag = f2.ev(lon,latitude_geocentric)
     else:


### PR DESCRIPTION
refactor: import `shapely` and osgeo`
feat: added option to not run with crossover measurements (thanks @iceisnice for the suggestion!)